### PR TITLE
Fix clojure link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Note_: to follow the progression, check also other branches such as `step0`, `step1`, etc.
 
-**Requirements**: JDK (Java Development Kit), [Clojure](https://clojure).
+**Requirements**: JDK (Java Development Kit), [Clojure](https://clojure.org/).
 
 To run directly (without REPL):
 ```


### PR DESCRIPTION
From `https://clojure/` into `https://clojure.org/`